### PR TITLE
OAuth: Remove socket listeners on unmount

### DIFF
--- a/template/client/src/components/modules/OAuth.js
+++ b/template/client/src/components/modules/OAuth.js
@@ -43,6 +43,12 @@ class OAuth extends Component {
       this.popup.close();
     });
   }
+  
+  componentWillUnmount() {
+    const { provider } = this.props;
+    socket.removeAllListeners(provider);
+  }
+
 
   render() {
     const { provider } = this.props;


### PR DESCRIPTION
fixes a bug where if the oauth component remounts, multiple socket listeners could be active at once and make auth explode